### PR TITLE
Update CI and Toast configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,11 @@ jobs:
     name: Validate
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
       with:
         submodules: recursive
     - if: ${{ github.event_name == 'push' }}
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4.1.0
       with:
         username: stephanmisc
         password: ${{ secrets.DOCKER_PASSWORD }}

--- a/toast.yml
+++ b/toast.yml
@@ -1,4 +1,4 @@
-image: ubuntu:24.04
+image: ubuntu:26.04
 user: user
 command_prefix: |
   # Make Bash log commands and not silently ignore errors.


### PR DESCRIPTION
## Summary
- update the pinned GitHub Actions versions in CI
- bump the Toast base image to `ubuntu:26.04`
- keep the builder dependency update separate in https://github.com/chriskempson/base16-builder-php/pull/2 because the submodule points at the upstream repository

## Validation
- `toast lint build`