### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     name: Validate
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7.0.0
+    - uses: actions/checkout@v7.0.1
       with:
         submodules: recursive
     - if: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
Updates actions/checkout 7.0.0 → 7.0.1. Package dependencies, toolchains, submodules, and the 2026 copyright notice were already current.

Upstream release notes were reviewed; no source changes or migrations are required.

**Status:** Ready

**Fixes:** N/A