### PR TITLE
Update nvim-base16 repository URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/chriskempson/base16-shell
 [submodule "base16-nvim"]
 	path = base16-nvim
-	url = https://github.com/bradcush/base16-nvim
+	url = https://github.com/bradcush/nvim-base16


### PR DESCRIPTION
Updates the Neovim Base16 submodule URL from the former `bradcush/base16-nvim` name to its canonical `bradcush/nvim-base16` name. The gitlink already points to the latest commit on upstream `main` (`ace1d9c`), so no pin change is needed.

**Status:** Ready

**Fixes:** N/A